### PR TITLE
Fix CodeQL file race and insecure temp file findings

### DIFF
--- a/src/modules/encryption/encryption-ipc.js
+++ b/src/modules/encryption/encryption-ipc.js
@@ -108,6 +108,22 @@ export function decryptContent(encryptedContent, recoveryKey) {
  */
 export function createEncryptionManager(deps) {
   const { ipcMain, preferencesManager, getWindow, app } = deps;
+
+  const readMetaJson = (metaPath) => {
+    const metaContent = fs.readFileSync(metaPath, 'utf-8');
+    return JSON.parse(metaContent);
+  };
+
+  const writeMetaJson = (metaPath, meta) => {
+    const payload = JSON.stringify(meta, null, 2);
+    const fd = fs.openSync(metaPath, 'r+');
+    try {
+      fs.ftruncateSync(fd, 0);
+      fs.writeFileSync(fd, payload, { encoding: 'utf-8' });
+    } finally {
+      fs.closeSync(fd);
+    }
+  };
   
   // 加密状态管理（无锁定功能）
   let encryptionEnabled = false;
@@ -150,13 +166,20 @@ export function createEncryptionManager(deps) {
     try {
       const databaseDir = path.join(app.getPath('documents'), 'NoteWizard', 'Database');
       const metaPath = path.join(databaseDir, 'meta.json');
-      
-      if (!fs.existsSync(metaPath)) {
+
+      let meta;
+      try {
+        meta = readMetaJson(metaPath);
+      } catch (error) {
+        if (error.code === 'ENOENT') {
+          return;
+        }
+        throw error;
+      }
+
+      if (!meta || typeof meta !== 'object') {
         return;
       }
-      
-      const metaContent = fs.readFileSync(metaPath, 'utf-8');
-      const meta = JSON.parse(metaContent);
       
       // 检查是否有临时恢复密钥
       if (!meta.tempRecoveryKey) {
@@ -172,7 +195,7 @@ export function createEncryptionManager(deps) {
         console.error('[Encryption] Invalid recovery key format in meta.json');
         // 清除无效的密钥
         delete meta.tempRecoveryKey;
-        fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
+        writeMetaJson(metaPath, meta);
         return;
       }
       
@@ -213,7 +236,7 @@ export function createEncryptionManager(deps) {
               console.error('[Encryption] Recovery key verification failed:', error.message);
               // 密钥验证失败，清除无效密钥
               delete meta.tempRecoveryKey;
-              fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
+              writeMetaJson(metaPath, meta);
               console.log('[Encryption] Invalid recovery key removed from meta.json');
               return;
             }
@@ -254,7 +277,7 @@ export function createEncryptionManager(deps) {
           
           // 清除 meta.json 中的临时密钥
           delete meta.tempRecoveryKey;
-          fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
+          writeMetaJson(metaPath, meta);
           console.log('[Encryption] Temporary recovery key removed from meta.json');
         }
       }
@@ -696,15 +719,14 @@ export function createEncryptionManager(deps) {
       // 更新 meta.json 的加密状态
       try {
         const metaPath = path.join(databaseDir, 'meta.json');
-        if (fs.existsSync(metaPath)) {
-          const metaContent = fs.readFileSync(metaPath, 'utf-8');
-          const meta = JSON.parse(metaContent);
-          meta.encrypted = true;
-          fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
-          console.log('[Encryption] Updated meta.json: encrypted = true');
-        }
+        const meta = readMetaJson(metaPath);
+        meta.encrypted = true;
+        writeMetaJson(metaPath, meta);
+        console.log('[Encryption] Updated meta.json: encrypted = true');
       } catch (error) {
-        console.error('Failed to update meta.json:', error);
+        if (error.code !== 'ENOENT') {
+          console.error('Failed to update meta.json:', error);
+        }
       }
       
       return { 
@@ -833,15 +855,14 @@ export function createEncryptionManager(deps) {
       // 更新 meta.json 的加密状态
       try {
         const metaPath = path.join(databaseDir, 'meta.json');
-        if (fs.existsSync(metaPath)) {
-          const metaContent = fs.readFileSync(metaPath, 'utf-8');
-          const meta = JSON.parse(metaContent);
-          meta.encrypted = false;
-          fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
-          console.log('[Encryption] Updated meta.json: encrypted = false');
-        }
+        const meta = readMetaJson(metaPath);
+        meta.encrypted = false;
+        writeMetaJson(metaPath, meta);
+        console.log('[Encryption] Updated meta.json: encrypted = false');
       } catch (error) {
-        console.error('Failed to update meta.json:', error);
+        if (error.code !== 'ENOENT') {
+          console.error('Failed to update meta.json:', error);
+        }
       }
       
       return { 

--- a/src/modules/import-export/notewizard-exporter.js
+++ b/src/modules/import-export/notewizard-exporter.js
@@ -206,7 +206,12 @@ export function createExporter(dependencies) {
         if (content.startsWith('ENCRYPTED:')) {
           // 使用公共函数解密
           const decryptedContent = decryptContent(content, recoveryKey);
-          fs.writeFileSync(targetFile, decryptedContent, 'utf-8');
+          const fd = fs.openSync(targetFile, 'wx', 0o600);
+          try {
+            fs.writeFileSync(fd, decryptedContent, { encoding: 'utf-8' });
+          } finally {
+            fs.closeSync(fd);
+          }
           decrypted++;
         } else {
           // 非加密文件，直接复制
@@ -314,8 +319,7 @@ export function createExporter(dependencies) {
 
       // 如果有加密文件，创建临时目录并解密
       if (hasEncrypted && recoveryKey) {
-        tempDir = path.join(os.tmpdir(), `notewizard-export-${Date.now()}`);
-        fs.mkdirSync(tempDir, { recursive: true });
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'notewizard-export-'));
 
         // 处理 objects 目录
         const tempObjectsDir = path.join(tempDir, 'objects');


### PR DESCRIPTION
### Motivation
- Address CodeQL alerts for TOCTOU file-system race conditions when reading/writing `meta.json` and for insecure temporary file creation during export decryption.
- Prevent possible attacker-controlled symlink/overwrite scenarios and harden temporary file creation to reduce privileged data exposure.

### Description
- Introduced `readMetaJson` and `writeMetaJson` helpers in `src/modules/encryption/encryption-ipc.js` and replaced ad-hoc `existsSync`/read/write patterns with ENOENT-safe reads and exclusive/truncate-based writes using file descriptors.
- Replaced `fs.writeFileSync(metaPath, ...)` calls with `writeMetaJson(metaPath, meta)` at all `meta.json` mutation sites (recovery, batch encrypt, batch decrypt) and suppress `ENOENT`-only errors when updating state.
- In `src/modules/import-export/notewizard-exporter.js` switched temporary directory creation to `fs.mkdtempSync(...)` and changed decrypted temp-file creation to use `fs.openSync(..., 'wx', 0o600')` followed by `fs.writeFileSync(fd, ...)`/`fs.closeSync(fd)` to ensure exclusive, permission-restricted file creation.

### Testing
- Ran `node --check src/modules/encryption/encryption-ipc.js` and it succeeded.
- Ran `node --check src/modules/import-export/notewizard-exporter.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e946c33bc832291415ceeb9c10d0e)