### PR TITLE
Harden ToS sync validation for downloaded content

### DIFF
--- a/scripts/sync-terms-of-service.js
+++ b/scripts/sync-terms-of-service.js
@@ -7,6 +7,8 @@ const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 
 const wikiRawUrl = 'https://raw.githubusercontent.com/wiki/jetyu/NoteWizard/T01_Terms-of-Service.md';
+const allowedWikiHost = 'raw.githubusercontent.com';
+const maxTermsSizeBytes = 200 * 1024;
 
 const outputPath = path.join(repoRoot, 'src', 'assets', 'terms-of-service', 'local-tos.txt');
 
@@ -23,7 +25,52 @@ function markdownToText(markdown) {
     .trim();
 }
 
+function validateSourceUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  if (url.protocol !== 'https:') {
+    throw new Error(`Unexpected protocol for terms source: ${url.protocol}`);
+  }
+
+  if (url.hostname !== allowedWikiHost) {
+    throw new Error(`Unexpected host for terms source: ${url.hostname}`);
+  }
+
+  if (!url.pathname.startsWith('/wiki/jetyu/NoteWizard/')) {
+    throw new Error(`Unexpected path for terms source: ${url.pathname}`);
+  }
+}
+
+function validateResponse(response) {
+  const contentType = response.headers.get('content-type') || '';
+  if (!/^text\//i.test(contentType)) {
+    throw new Error(`Unexpected content type for terms source: ${contentType || 'unknown'}`);
+  }
+
+  const contentLengthHeader = response.headers.get('content-length');
+  const contentLength = Number(contentLengthHeader || 0);
+  if (Number.isFinite(contentLength) && contentLength > maxTermsSizeBytes) {
+    throw new Error(`Terms source too large: ${contentLength} bytes`);
+  }
+}
+
+function sanitizeTermsText(text) {
+  const normalized = text
+    .replace(/\u0000/g, '')
+    .replace(/[\u0001-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '');
+
+  if (!/terms of service/i.test(normalized)) {
+    throw new Error('Downloaded terms content failed validation.');
+  }
+
+  if (Buffer.byteLength(normalized, 'utf8') > maxTermsSizeBytes) {
+    throw new Error('Downloaded terms content exceeded size limit after processing.');
+  }
+
+  return normalized;
+}
+
 async function main() {
+  validateSourceUrl(wikiRawUrl);
   await fs.mkdir(path.dirname(outputPath), { recursive: true });
 
   let existing = '';
@@ -36,9 +83,10 @@ async function main() {
   try {
     const response = await fetch(wikiRawUrl);
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    validateResponse(response);
 
     const markdown = await response.text();
-    const text = markdownToText(markdown) + '\n';
+    const text = sanitizeTermsText(markdownToText(markdown)) + '\n';
     await fs.writeFile(outputPath, '\ufeff' + text, 'utf8');
     console.log(`Synced Terms of Service from wiki: ${wikiRawUrl}`);
     return;


### PR DESCRIPTION
### Motivation
- Address a CodeQL finding about writing untrusted network data to disk by establishing explicit source and content validation before persisting remote Terms of Service.
- Limit the blast radius of malformed or malicious content by enforcing protocol/host/path allowlist, content-type and size checks, and basic content sanity checks.
- Preserve existing resilience by keeping the fallback behavior to the local file when network fetch is unavailable or validation fails.

### Description
- Add `allowedWikiHost` and `maxTermsSizeBytes` constants and perform source validation in `validateSourceUrl` to require `https`, the expected host, and an expected path prefix for the ToS URL.
- Add `validateResponse` to check `content-type` and `content-length` headers before reading the body.
- Add `sanitizeTermsText` to strip control characters, enforce a size cap, and require a `terms of service` marker in the normalized text before writing.
- Integrate the new validations into the main flow and keep the existing fallback that retains a local ToS file when fetch/validation fails.

### Testing
- Ran `node --check scripts/sync-terms-of-service.js` which completed without syntax errors.
- Ran `node scripts/sync-terms-of-service.js` in the CI-like environment where remote fetch failed, and the script logged the fallback behavior and kept the local ToS as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa5fcba2ac83229a19216ea2a5bf8c)