### PR TITLE
CodeQL workflow: checkout `develop` explicitly for scheduled runs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,14 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout repository
+      - name: Checkout repository (schedule -> develop)
+        if: github.event_name == 'schedule'
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Checkout repository (non-schedule)
+        if: github.event_name != 'schedule'
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL


### PR DESCRIPTION
### Motivation
- Ensure scheduled CodeQL scans run against the `develop` branch instead of the default checkout ref when triggered by the cron `schedule` event.

### Description
- Split the single checkout step into two conditional steps so that when `github.event_name == 'schedule'` the workflow uses `actions/checkout@v4` with `ref: develop`, and when the event is not `schedule` it performs a normal checkout.

### Testing
- No automated tests were modified or executed for this workflow-only change; CI will exercise the updated workflow on the next scheduled or push event.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aae9b948608322b9c5dfcff2cef3a5)