### PR TITLE
Centralize error handling, add global handlers, tighten CSP, and add IPC typings

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -12,6 +12,7 @@ import { updaterService } from './services/updater.service.js';
 import { IPC_CHANNELS } from './constants/ipc.constants.js';
 import { vfsService } from './services/vfs.service.js';
 import { accessControlService } from './services/access-control.service.js';
+import { errorService } from './services/error.service.js';
 
 const WORKSPACE_RESOURCE_SCHEME = 'note-resource';
 
@@ -92,6 +93,8 @@ function registerPreviewSecurityPolicies(electronSession: Electron.Session): voi
   });
 }
 
+errorService.registerGlobalErrorHandlers();
+
 app.whenReady().then(async () => {
   registerWorkspaceResourceProtocol();
   const preferences = await settingsService.loadConfig();
@@ -148,4 +151,3 @@ app.on(IPC_CHANNELS.ELECTRON_BEFORE_QUIT, () => {
   trayService.destroy();
   updaterService.destroy();
 });
-

--- a/electron/main/ipc/modules/ai-chat.ts
+++ b/electron/main/ipc/modules/ai-chat.ts
@@ -4,7 +4,7 @@ import { remoteAiService } from '../../services/remote-ai.service.js';
 import { aiConfigService } from '../../services/ai-config.service.js';
 import { IPC_CHANNELS } from '../../constants/ipc.constants.js';
 import { loggerService } from '../../services/logger.service.js';
-import { getErrorMessage } from '../../utils/error.utils.js';
+import { getErrorMessage } from '../../services/error.service.js';
 
 const logger = loggerService.createLogger('Electron:AI Chat IPC');
 

--- a/electron/main/ipc/modules/ai-source.ts
+++ b/electron/main/ipc/modules/ai-source.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { IPC_CHANNELS } from '../../constants/ipc.constants.js';
 import { remoteAiService } from '../../services/remote-ai.service.js';
 import { loggerService } from '../../services/logger.service.js';
-import { getErrorMessage } from '../../utils/error.utils.js';
+import { getErrorMessage } from '../../services/error.service.js';
 
 const logger = loggerService.createLogger('Electron:AI Source IPC');
 

--- a/electron/main/ipc/modules/e2ee.ts
+++ b/electron/main/ipc/modules/e2ee.ts
@@ -5,7 +5,7 @@ import { IPC_CHANNELS } from '../../constants/ipc.constants.js';
 import { ACCESS_CONTROL_TIMEOUT_OPTIONS, type AccessControlTimeout } from '../../../shared/e2ee.constants.js';
 import { keyManagerService } from '../../services/key-manager.service.js';
 import { accessControlService } from '../../services/access-control.service.js';
-import { getErrorCode, getErrorMessage } from '../../utils/error.utils.js';
+import { getErrorCode, getErrorMessage } from '../../services/error.service.js';
 
 function serializeE2eeError(error: unknown): {
   success: false;

--- a/electron/main/ipc/modules/rag.ts
+++ b/electron/main/ipc/modules/rag.ts
@@ -11,7 +11,7 @@ import { remoteAiService } from '../../services/remote-ai.service.js';
 import { aiConfigService } from '../../services/ai-config.service.js';
 import { IPC_CHANNELS } from '../../constants/ipc.constants.js';
 import { loggerService } from '../../services/logger.service.js';
-import { getErrorMessage } from '../../utils/error.utils.js';
+import { getErrorMessage } from '../../services/error.service.js';
 
 const logger = loggerService.createLogger('Main:RAG IPC');
 

--- a/electron/main/ipc/modules/search.ts
+++ b/electron/main/ipc/modules/search.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { IPC_CHANNELS } from '../../constants/ipc.constants.js';
 import { searchService } from '../../services/search.service.js';
 import { loggerService } from '../../services/logger.service.js';
-import { getErrorMessage } from '../../utils/error.utils.js';
+import { getErrorMessage } from '../../services/error.service.js';
 
 const logger = loggerService.createLogger('Main:Search IPC');
 

--- a/electron/main/ipc/modules/sync.ts
+++ b/electron/main/ipc/modules/sync.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { IPC_CHANNELS } from '../../constants/ipc.constants.js';
 import { syncService } from '../../services/sync/sync.service.js';
 import { SYNC_INTERVALS, SYNC_PROVIDERS, SYNC_TRIGGERS } from '../../../shared/sync.constants.js';
-import { getErrorCode, getErrorMessage } from '../../utils/error.utils.js';
+import { getErrorCode, getErrorMessage } from '../../services/error.service.js';
 
 const providerSchema = z.enum([SYNC_PROVIDERS.WEBDAV, SYNC_PROVIDERS.OSS_S3]);
 const intervalSchema = z.union([

--- a/electron/main/services/embedding.service.ts
+++ b/electron/main/services/embedding.service.ts
@@ -1,6 +1,6 @@
 import { remoteAiService } from './remote-ai.service.js';
 import { loggerService } from './logger.service.js';
-import { getErrorMessage } from '../utils/error.utils.js';
+import { getErrorMessage } from '../services/error.service.js';
 
 const logger = loggerService.createLogger('Electron:Embedding Service');
 

--- a/electron/main/services/error.service.ts
+++ b/electron/main/services/error.service.ts
@@ -1,0 +1,65 @@
+import { app } from 'electron';
+import { loggerService } from './logger.service.js';
+import { serializeError } from '../../shared/utils/error.utils.js';
+
+const GLOBAL_ERROR_SOURCE = 'MainGlobalError';
+
+interface ErrorMetadata {
+  [key: string]: string | number | boolean | null;
+}
+
+function reportGlobalError(event: string, error: unknown, metadata?: ErrorMetadata): void {
+  const serializedError = serializeError(error);
+  loggerService.error(GLOBAL_ERROR_SOURCE, `${event} captured`, {
+    ...serializedError,
+    ...(metadata ?? {}),
+  });
+}
+
+class ErrorService {
+  private hasRegisteredGlobalHandlers = false;
+
+  registerGlobalErrorHandlers(): void {
+    if (this.hasRegisteredGlobalHandlers) {
+      return;
+    }
+
+    this.hasRegisteredGlobalHandlers = true;
+
+    process.on('uncaughtException', (error: Error) => {
+      reportGlobalError('uncaughtException', error);
+    });
+
+    process.on('unhandledRejection', (reason: unknown) => {
+      reportGlobalError('unhandledRejection', reason);
+    });
+
+    app.on('render-process-gone', (_event, webContents, details) => {
+      reportGlobalError('render-process-gone', new Error('Renderer process exited unexpectedly'), {
+        reason: details.reason,
+        exitCode: details.exitCode,
+        webContentsId: webContents.id,
+      });
+    });
+
+    app.on('child-process-gone', (_event, details) => {
+      reportGlobalError('child-process-gone', new Error('Child process exited unexpectedly'), {
+        type: details.type,
+        reason: details.reason,
+        exitCode: details.exitCode,
+        serviceName: details.serviceName ?? null,
+        name: details.name ?? null,
+      });
+    });
+  }
+}
+
+export const errorService = new ErrorService();
+
+
+export {
+  getErrorCode,
+  getErrorMessage,
+  serializeError,
+  type SerializedError,
+} from '../../shared/utils/error.utils.js';

--- a/electron/main/services/history.service.ts
+++ b/electron/main/services/history.service.ts
@@ -4,7 +4,7 @@ import { VFS_CONSTANTS } from '../constants/vfs.constants.js';
 import { loggerService } from './logger.service.js';
 import { writeUtf8 } from './file.service.js';
 import { formatSnapshotFilename, filenameToTimestamp } from '../utils/formatTools.js';
-import { getErrorMessage } from '../utils/error.utils.js';
+import { getErrorMessage } from '../services/error.service.js';
 
 const historyLogger = loggerService.createLogger('Electron:History Service');
 

--- a/electron/main/services/import-export/import-export.service.ts
+++ b/electron/main/services/import-export/import-export.service.ts
@@ -4,7 +4,7 @@ import { sppxExportService } from './sppx-export.service.js';
 import { sppxImportService } from './sppx-import.service.js';
 import { markdownExportService } from './markdown-export.service.js';
 import { markdownImportService } from './markdown-import.service.js';
-import { getErrorMessage } from '../../utils/error.utils.js';
+import { getErrorMessage } from '../../services/error.service.js';
 
 const logger = loggerService.createLogger('Main:Import Export Service');
 type AppSettings = Awaited<ReturnType<typeof settingsService.loadConfig>>;

--- a/electron/main/services/import-export/markdown-export.service.ts
+++ b/electron/main/services/import-export/markdown-export.service.ts
@@ -15,7 +15,7 @@ import {
   replaceMarkdownImageDestinations,
   sanitizeFsName,
 } from './markdown.utils.js';
-import { getErrorMessage } from '../../utils/error.utils.js';
+import { getErrorMessage } from '../../services/error.service.js';
 
 const logger = loggerService.createLogger('Main:Markdown Export Service');
 

--- a/electron/main/services/import-export/markdown-import.service.ts
+++ b/electron/main/services/import-export/markdown-import.service.ts
@@ -14,7 +14,7 @@ import {
   replaceMarkdownImageDestinations,
   sanitizeFsName,
 } from './markdown.utils.js';
-import { getErrorMessage } from '../../utils/error.utils.js';
+import { getErrorMessage } from '../../services/error.service.js';
 
 const logger = loggerService.createLogger('Main:Markdown Import Service');
 const SYSTEM_DIRECTORY_NAMES = new Set<string>([

--- a/electron/main/services/import-export/sppx-export.service.ts
+++ b/electron/main/services/import-export/sppx-export.service.ts
@@ -6,7 +6,7 @@ import { VFS_CONSTANTS } from '../../constants/vfs.constants.js';
 import { loggerService } from '../logger.service.js';
 import { vfsService } from '../vfs.service.js';
 import { createZipArchiveFromDirectory } from './zip.utils.js';
-import { getErrorMessage } from '../../utils/error.utils.js';
+import { getErrorMessage } from '../../services/error.service.js';
 
 const logger = loggerService.createLogger('Main:SPPX Export Service');
 const PACKAGE_EXTENSIONS = new Set(['.nwp', '.sppx']);

--- a/electron/main/services/import-export/sppx-import.service.ts
+++ b/electron/main/services/import-export/sppx-import.service.ts
@@ -10,7 +10,7 @@ import { vfsService } from '../vfs.service.js';
 import { ragService } from '../rag.service.js';
 import { syncStateService } from '../sync/state.service.js';
 import { extractZipArchiveToDirectory } from './zip.utils.js';
-import { getErrorCode, getErrorMessage } from '../../utils/error.utils.js';
+import { getErrorCode, getErrorMessage } from '../../services/error.service.js';
 
 const logger = loggerService.createLogger('Main:SPPX Import Service');
 

--- a/electron/main/services/key-manager.service.ts
+++ b/electron/main/services/key-manager.service.ts
@@ -10,7 +10,7 @@ import {
 import { VFS_CONSTANTS } from '../constants/vfs.constants.js';
 import { loggerService } from './logger.service.js';
 import { cryptoService, type KeySlots, type WrappedKey } from './crypto.service.js';
-import { getErrorCode, getErrorMessage } from '../utils/error.utils.js';
+import { getErrorCode, getErrorMessage } from '../services/error.service.js';
 
 const logger = loggerService.createLogger('Electron:Key Manager');
 const E2EE_ERROR_CODE_SET = new Set<E2eeErrorCode>(

--- a/electron/main/services/logger.service.ts
+++ b/electron/main/services/logger.service.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { app, shell } from 'electron';
 import { formatTimestamp } from '../utils/formatTools.js';
-import { getErrorMessage } from '../utils/error.utils.js';
+import { getErrorMessage } from '../services/error.service.js';
 
 const LOG_AUTO_CLEAR_DAY_OPTIONS = new Set([0, 10, 20]);
 const DAY_IN_MS = 24 * 60 * 60 * 1000;

--- a/electron/main/services/preview-policy.service.ts
+++ b/electron/main/services/preview-policy.service.ts
@@ -68,14 +68,21 @@ export const previewPolicyService = {
 
   buildContentSecurityPolicy({ isDev = false }: { isDev?: boolean } = {}): string {
     const imageSources = ["'self'", 'data:', 'blob:', 'note-resource:', 'https:'];
+
+    // Allow full remote image loading mode to include http origins by CSP as well,
+    // otherwise runtime policy and CSP would conflict.
+    if (currentPreviewAppearance.remoteImageMode === 'all') {
+      imageSources.push('http:');
+    }
+
     if (isDev) {
       imageSources.push(DEV_SERVER_IMAGE_ORIGIN);
     }
 
-    return [
+    const cspDirectives = [
       "default-src 'self'",
       "script-src 'self'",
-      "style-src 'self' 'unsafe-inline'",
+      "style-src 'self'",
       `img-src ${imageSources.join(' ')}`,
       "font-src 'self' data:",
       "connect-src 'self'",
@@ -83,7 +90,14 @@ export const previewPolicyService = {
       "base-uri 'self'",
       "form-action 'none'",
       "frame-src 'none'",
-    ].join('; ');
+      "frame-ancestors 'none'",
+    ];
+
+    if (currentPreviewAppearance.remoteImageMode !== 'all') {
+      cspDirectives.push('upgrade-insecure-requests', 'block-all-mixed-content');
+    }
+
+    return cspDirectives.join('; ');
   },
 
   isAllowedRemoteImageRequest(url: unknown, { isDev = false }: { isDev?: boolean } = {}): boolean {

--- a/electron/main/services/rag.service.ts
+++ b/electron/main/services/rag.service.ts
@@ -2,7 +2,7 @@ import { vectorStoreService } from './vector-store.service.js';
 import { generateEmbeddingsBatch } from './embedding.service.js';
 import { chunkMarkdown } from '../utils/text-chunker.js';
 import { loggerService } from './logger.service.js';
-import { getErrorMessage } from '../utils/error.utils.js';
+import { getErrorMessage } from '../services/error.service.js';
 
 const logger = loggerService.createLogger('Main:RAG Service');
 

--- a/electron/main/services/remote-ai.service.ts
+++ b/electron/main/services/remote-ai.service.ts
@@ -1,5 +1,5 @@
 import { loggerService } from './logger.service.js';
-import { getErrorMessage } from '../utils/error.utils.js';
+import { getErrorMessage } from '../services/error.service.js';
 
 const logger = loggerService.createLogger('Electron:Remote AI Service');
 

--- a/electron/main/services/search.service.ts
+++ b/electron/main/services/search.service.ts
@@ -1,6 +1,6 @@
 import { vfsService } from './vfs.service.js';
 import { loggerService } from './logger.service.js';
-import { getErrorMessage } from '../utils/error.utils.js';
+import { getErrorMessage } from '../services/error.service.js';
 
 const logger = loggerService.createLogger('Main:Search Service');
 

--- a/electron/main/services/shortcuts.service.ts
+++ b/electron/main/services/shortcuts.service.ts
@@ -12,7 +12,7 @@ import { VFS_CONSTANTS } from '../constants/vfs.constants.js';
 import { getAllCommands } from '../constants/commands.constants.js';
 import { $t } from '../utils/i18n.js';
 import { loggerService } from './logger.service.js';
-import { getErrorCode, getErrorMessage } from '../utils/error.utils.js';
+import { getErrorCode, getErrorMessage } from '../services/error.service.js';
 
 const logger = loggerService.createLogger('Electron:Shortcuts Service');
 

--- a/electron/main/services/updater.service.ts
+++ b/electron/main/services/updater.service.ts
@@ -5,7 +5,7 @@ import { loggerService } from './logger.service.js';
 import { settingsService } from './settings.service.js';
 import { trayService } from './tray.service.js';
 import { UPDATER_CONSTANTS } from '../constants/updater.constants.js';
-import { getErrorCode, getErrorMessage } from '../utils/error.utils.js';
+import { getErrorCode, getErrorMessage } from '../services/error.service.js';
 
 const logger = loggerService.createLogger('Software Updater');
 

--- a/electron/main/services/vector-store.service.ts
+++ b/electron/main/services/vector-store.service.ts
@@ -2,7 +2,7 @@ import * as lancedb from '@lancedb/lancedb';
 import path from 'node:path';
 import { promises as fs } from 'node:fs';
 import { loggerService } from './logger.service.js';
-import { getErrorMessage } from '../utils/error.utils.js';
+import { getErrorMessage } from '../services/error.service.js';
 
 const logger = loggerService.createLogger('Electron:Vector Store Service');
 

--- a/electron/main/services/vfs.service.ts
+++ b/electron/main/services/vfs.service.ts
@@ -15,7 +15,7 @@ import { writeUtf8 } from './file.service.js';
 import { loggerService } from './logger.service.js';
 import { historyService } from './history.service.js';
 import { settingsService } from './settings.service.js';
-import { getErrorMessage } from '../utils/error.utils.js';
+import { getErrorMessage } from '../services/error.service.js';
 
 const logger = loggerService.createLogger('Electron:VFS Service');
 

--- a/electron/main/utils/error.utils.ts
+++ b/electron/main/utils/error.utils.ts
@@ -1,6 +1,0 @@
-export {
-  getErrorCode,
-  getErrorMessage,
-  serializeError,
-  type SerializedError,
-} from '../../shared/utils/error.utils.js';

--- a/electron/main/utils/i18n.ts
+++ b/electron/main/utils/i18n.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { VFS_CONSTANTS } from '../constants/vfs.constants.js';
 import { loggerService } from '../services/logger.service.js';
-import { getErrorMessage } from './error.utils.js';
+import { getErrorMessage } from '../services/error.service.js';
 
 const logger = loggerService.createLogger('Electron:I18n Utils');
 

--- a/electron/preload/src/initPreloadCore.ts
+++ b/electron/preload/src/initPreloadCore.ts
@@ -7,9 +7,20 @@ type JsonObject = { [key: string]: JsonValue };
 type VoidCallback = () => void;
 type DataCallback<T = unknown> = (data: T) => void;
 
+interface SaveFilePayload { filePath: string | null; content: string; }
+interface WorkspaceContextMenuItemPayload { action?: string | null; labelKey?: string; label?: string; type?: 'normal' | 'separator' | 'submenu'; enabled?: boolean; submenu?: WorkspaceContextMenuItemPayload[]; }
+interface WorkspaceContextMenuPayload { nodeId: string; nodeType?: string; isRoot?: boolean; items?: WorkspaceContextMenuItemPayload[]; }
+interface EditorContextMenuPayload { selectedText?: string; hasSelection?: boolean; canPaste?: boolean; }
+interface AiSourceTestConnectionPayload { aiEndpoint: string; aiApiKey: string; aiModel: string; }
+type SyncProviderConfigPayload = JsonObject & { provider: string };
+interface SyncRunPayload { config: JsonObject; trigger: 'manual' | 'timer' | 'save'; }
+interface ShortcutKeybindingPayload { commandId: string; key: string; when?: string | null; }
+type RagQueryPayload = JsonObject;
+type AiChatPayload = JsonObject;
+
 const electronAPI = Object.freeze({
   openFile: () => ipcRenderer.invoke(IPC_CHANNELS.OPEN_FILE),
-  saveFile: (payload: Record<string, unknown>) => ipcRenderer.invoke(IPC_CHANNELS.SAVE_FILE, payload),
+  saveFile: (payload: SaveFilePayload) => ipcRenderer.invoke(IPC_CHANNELS.SAVE_FILE, payload),
   logger: Object.freeze({
     log: (payload: { level: string; source: string; message: string; context?: JsonValue }) =>
       ipcRenderer.send(IPC_CHANNELS.LOGGER_LOG, payload),
@@ -72,12 +83,12 @@ const electronAPI = Object.freeze({
     searchNotes: (query: string) => ipcRenderer.invoke(IPC_CHANNELS.SEARCH_NOTES, query),
   }),
   workspace: Object.freeze({
-    showContextMenu: (payload: Record<string, unknown>) => ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_SHOW_CONTEXT_MENU, payload),
+    showContextMenu: (payload: WorkspaceContextMenuPayload) => ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_SHOW_CONTEXT_MENU, payload),
     getDailyWallpaper: (payload?: { nextArchive?: boolean; currentArchiveIndex?: number }) =>
       ipcRenderer.invoke(IPC_CHANNELS.APP_GET_WALLPAPER, payload),
   }),
   editor: Object.freeze({
-    showContextMenu: (payload: Record<string, unknown>) => ipcRenderer.invoke(IPC_CHANNELS.EDITOR_SHOW_CONTEXT_MENU, payload),
+    showContextMenu: (payload: EditorContextMenuPayload) => ipcRenderer.invoke(IPC_CHANNELS.EDITOR_SHOW_CONTEXT_MENU, payload),
     readClipboard: () => ipcRenderer.invoke(IPC_CHANNELS.EDITOR_READ_CLIPBOARD),
     writeClipboard: (text: string) => ipcRenderer.invoke(IPC_CHANNELS.EDITOR_WRITE_CLIPBOARD, text),
   }),
@@ -124,20 +135,20 @@ const electronAPI = Object.freeze({
     importMarkdown: () => ipcRenderer.invoke(IPC_CHANNELS.DATA_IMPORT_MARKDOWN),
   }),
   aiSource: Object.freeze({
-    testConnection: (config: Record<string, unknown>) => ipcRenderer.invoke(IPC_CHANNELS.AI_SOURCE_TEST_CONNECTION, config),
+    testConnection: (config: AiSourceTestConnectionPayload) => ipcRenderer.invoke(IPC_CHANNELS.AI_SOURCE_TEST_CONNECTION, config),
   }),
   sync: Object.freeze({
-    testConnection: (config: Record<string, unknown>) => ipcRenderer.invoke(IPC_CHANNELS.SYNC_TEST_CONNECTION, config),
-    run: (payload: Record<string, unknown>) => ipcRenderer.invoke(IPC_CHANNELS.SYNC_RUN, payload),
+    testConnection: (config: SyncProviderConfigPayload) => ipcRenderer.invoke(IPC_CHANNELS.SYNC_TEST_CONNECTION, config),
+    run: (payload: SyncRunPayload) => ipcRenderer.invoke(IPC_CHANNELS.SYNC_RUN, payload),
     getStatus: () => ipcRenderer.invoke(IPC_CHANNELS.SYNC_GET_STATUS),
-    restoreRemoteKeySlots: (config: Record<string, unknown>) =>
+    restoreRemoteKeySlots: (config: SyncProviderConfigPayload) =>
       ipcRenderer.invoke(IPC_CHANNELS.SYNC_RESTORE_REMOTE_KEY_SLOTS, config),
   }),
   shortcuts: Object.freeze({
     getCommands: () => ipcRenderer.invoke(IPC_CHANNELS.SHORTCUTS_GET_COMMANDS),
     getCommandsByCategory: (category: string) => ipcRenderer.invoke(IPC_CHANNELS.SHORTCUTS_GET_COMMANDS_BY_CATEGORY, category),
     loadKeybindings: () => ipcRenderer.invoke(IPC_CHANNELS.SHORTCUTS_LOAD_KEYBINDINGS),
-    saveKeybindings: (keybindings: Array<Record<string, unknown>>) => ipcRenderer.invoke(IPC_CHANNELS.SHORTCUTS_SAVE_KEYBINDINGS, keybindings),
+    saveKeybindings: (keybindings: ShortcutKeybindingPayload[]) => ipcRenderer.invoke(IPC_CHANNELS.SHORTCUTS_SAVE_KEYBINDINGS, keybindings),
     addKeybinding: (payload: { commandId: string; key: string; when?: string | null }) =>
       ipcRenderer.invoke(IPC_CHANNELS.SHORTCUTS_ADD_KEYBINDING, payload),
     removeKeybinding: (payload: { commandId: string; key: string }) => ipcRenderer.invoke(IPC_CHANNELS.SHORTCUTS_REMOVE_KEYBINDING, payload),
@@ -149,20 +160,20 @@ const electronAPI = Object.freeze({
     normalizeKeybinding: (key: string) => ipcRenderer.invoke(IPC_CHANNELS.SHORTCUTS_NORMALIZE_KEYBINDING, key),
     getKeybindingsForCommand: (commandId: string) => ipcRenderer.invoke(IPC_CHANNELS.SHORTCUTS_GET_KEYBINDINGS_FOR_COMMAND, commandId),
     exportKeybindings: () => ipcRenderer.invoke(IPC_CHANNELS.SHORTCUTS_EXPORT_KEYBINDINGS),
-    importKeybindings: (config: Record<string, unknown>) => ipcRenderer.invoke(IPC_CHANNELS.SHORTCUTS_IMPORT_KEYBINDINGS, config),
+    importKeybindings: (config: JsonObject) => ipcRenderer.invoke(IPC_CHANNELS.SHORTCUTS_IMPORT_KEYBINDINGS, config),
   }),
   rag: Object.freeze({
     initialize: () => ipcRenderer.invoke(IPC_CHANNELS.RAG_INITIALIZE),
-    indexNote: (request: Record<string, unknown>) => ipcRenderer.invoke(IPC_CHANNELS.RAG_INDEX_NOTE, request),
-    rebuildIndex: (request: Record<string, unknown>) => ipcRenderer.invoke(IPC_CHANNELS.RAG_REBUILD_INDEX, request),
-    searchText: (request: Record<string, unknown>) => ipcRenderer.invoke(IPC_CHANNELS.RAG_SEARCH_TEXT, request),
-    askQuestion: (payload: Record<string, unknown>) => ipcRenderer.invoke(IPC_CHANNELS.RAG_ASK_QUESTION, payload),
+    indexNote: (request: RagQueryPayload) => ipcRenderer.invoke(IPC_CHANNELS.RAG_INDEX_NOTE, request),
+    rebuildIndex: (request: RagQueryPayload) => ipcRenderer.invoke(IPC_CHANNELS.RAG_REBUILD_INDEX, request),
+    searchText: (request: RagQueryPayload) => ipcRenderer.invoke(IPC_CHANNELS.RAG_SEARCH_TEXT, request),
+    askQuestion: (payload: RagQueryPayload) => ipcRenderer.invoke(IPC_CHANNELS.RAG_ASK_QUESTION, payload),
     deleteNoteIndex: (noteId: string) => ipcRenderer.invoke(IPC_CHANNELS.RAG_DELETE_NOTE_INDEX, noteId),
     getStatus: () => ipcRenderer.invoke(IPC_CHANNELS.RAG_GET_STATUS),
   }),
   aiChat: Object.freeze({
-    generate: (payload: Record<string, unknown>) => ipcRenderer.invoke(IPC_CHANNELS.AI_CHAT_GENERATE, payload),
-    generateCompletion: (payload: Record<string, unknown>) => ipcRenderer.invoke(IPC_CHANNELS.AI_CHAT_GENERATE_COMPLETION, payload),
+    generate: (payload: AiChatPayload) => ipcRenderer.invoke(IPC_CHANNELS.AI_CHAT_GENERATE, payload),
+    generateCompletion: (payload: AiChatPayload) => ipcRenderer.invoke(IPC_CHANNELS.AI_CHAT_GENERATE_COMPLETION, payload),
   }),
   updater: Object.freeze({
     check: (silent: boolean) => ipcRenderer.invoke(IPC_CHANNELS.UPDATER_CHECK, silent),

--- a/index.html
+++ b/index.html
@@ -7,14 +7,17 @@
   <meta http-equiv="Content-Security-Policy" content="
   default-src 'self'; 
   script-src 'self'; 
-  style-src 'self' 'unsafe-inline'; 
-  img-src 'self' data: blob: note-resource: https: http://127.0.0.1:5173;
+  style-src 'self'; 
+  img-src 'self' data: blob: note-resource: https:;
   font-src 'self' data:;
   connect-src 'self'; 
   object-src 'none';
   base-uri 'self';
   form-action 'none';
-  frame-src 'none';" />
+  frame-src 'none';
+  frame-ancestors 'none';
+  upgrade-insecure-requests;
+  block-all-mixed-content;" />
   <title>Snaptium</title>
 </head>
 

--- a/src/renderer/features/error/index.ts
+++ b/src/renderer/features/error/index.ts
@@ -1,0 +1,1 @@
+export * from './services/error.service';

--- a/src/renderer/features/error/services/error.service.ts
+++ b/src/renderer/features/error/services/error.service.ts
@@ -1,0 +1,60 @@
+import { createLogger } from '@renderer/features/logger';
+import { getErrorMessage, serializeError } from '@shared/utils/error.utils';
+
+const logger = createLogger('RendererGlobalError');
+
+let hasRegisteredGlobalErrorHandlers = false;
+
+function normalizeErrorContext(error: unknown) {
+  const serializedError = serializeError(error);
+  return {
+    name: serializedError.name,
+    message: serializedError.message,
+    code: serializedError.code,
+    stack: serializedError.stack,
+  };
+}
+
+export function registerRendererGlobalErrorHandlers(): void {
+  if (hasRegisteredGlobalErrorHandlers) {
+    return;
+  }
+
+  hasRegisteredGlobalErrorHandlers = true;
+
+  window.addEventListener('error', (event: ErrorEvent) => {
+    const error = event.error ?? event.message;
+    logger.error('window.error captured', {
+      ...normalizeErrorContext(error),
+      filename: event.filename || null,
+      lineno: event.lineno || null,
+      colno: event.colno || null,
+    });
+  });
+
+  window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
+    logger.error('window.unhandledrejection captured', normalizeErrorContext(event.reason));
+  });
+
+  logger.info('Renderer global error handlers registered');
+}
+
+export function withErrorBoundary<TArgs extends unknown[], TResult>(source: string, fn: (...args: TArgs) => TResult): (...args: TArgs) => TResult {
+  return (...args: TArgs): TResult => {
+    try {
+      return fn(...args);
+    } catch (error: unknown) {
+      logger.error(`${source} sync error captured`, normalizeErrorContext(error));
+      throw error;
+    }
+  };
+}
+
+export async function withErrorBoundaryAsync<TArgs extends unknown[], TResult>(source: string, fn: (...args: TArgs) => Promise<TResult>, args: TArgs): Promise<TResult> {
+  try {
+    return await fn(...args);
+  } catch (error: unknown) {
+    logger.error(`${source} async error captured: ${getErrorMessage(error)}`, normalizeErrorContext(error));
+    throw error;
+  }
+}

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -3,9 +3,25 @@ import { createPinia } from 'pinia';
 import App from './app/App.vue';
 import { i18n } from '@renderer/features/i18n';
 import './styles/main.css';
+import { registerRendererGlobalErrorHandlers } from '@renderer/features/error';
+import { createLogger } from '@renderer/features/logger';
+import { serializeError } from '@shared/utils/error.utils';
 import 'katex/dist/katex.min.css';
 
+const bootstrapLogger = createLogger('RendererBootstrap');
+
+registerRendererGlobalErrorHandlers();
+
 const app = createApp(App);
+app.config.errorHandler = (error, instance, info) => {
+  const serializedError = serializeError(error);
+  bootstrapLogger.error('vue.errorHandler captured', {
+    ...serializedError,
+    info,
+    component: instance?.$options?.name ?? null,
+  });
+};
+
 app.use(createPinia());
 app.use(i18n);
 app.mount('#app');


### PR DESCRIPTION
### Motivation

- Centralize error serialization and reporting in the main process and provide consistent error helpers to other modules. 
- Register global error handlers for uncaught exceptions, unhandled rejections and process/renderer/child exits to improve observability. 
- Align content-security-policy behavior between runtime preview policy and static HTML and make remote image loading modes consistent. 
- Improve type safety for preload IPC surface and add renderer-side global error logging for Vue errors and window errors.

### Description

- Added a new main process `error.service` that registers global handlers via `registerGlobalErrorHandlers` and exports `getErrorCode`, `getErrorMessage`, and `serializeError` re-exported from shared utils. 
- Replaced numerous internal imports of `../../utils/error.utils.js` with the new `../services/error.service.js` across many IPC modules and services, and removed the old `electron/main/utils/error.utils.ts` re-export file. 
- Registered main global handlers by calling `errorService.registerGlobalErrorHandlers()` from `electron/main/index.ts`. 
- Hardened preview content security policy in `preview-policy.service.ts` (adjusted `img-src`, added `http:` support for `remoteImageMode === 'all'`, added `frame-ancestors 'none'`, and conditionally added `upgrade-insecure-requests` and `block-all-mixed-content`), and synchronized the static `index.html` CSP accordingly. 
- Enhanced preload API typings in `electron/preload/src/initPreloadCore.ts` to strongly type many IPC payloads and adjusted several IPC signatures accordingly. 
- Added renderer-side error feature with `registerRendererGlobalErrorHandlers`, `withErrorBoundary`, and async variants in `src/renderer/features/error/services/error.service.ts`, and registered these handlers and a Vue `app.config.errorHandler` in `src/renderer/main.ts`. 

### Testing

- Ran TypeScript build/typecheck for main and renderer and confirmed the codebase compiles successfully. 
- Ran the test suite and automated unit tests (where present) and they completed without failures. 
- Verified the application starts in development mode and the new global error handlers are registered at startup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a7505197c832ebe13d0902c66c97d)