### PR TITLE
Add release health manifest generation to release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,6 +239,67 @@ jobs:
           mkdir -p release_files
           find artifacts -type f ! -name "*.md" -exec cp {} release_files/ \;
 
+      - name: Generate release health manifest
+        env:
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          node --input-type=module <<'NODE'
+          import fs from 'node:fs'
+          import path from 'node:path'
+
+          const releaseDir = 'release_files'
+          const version = process.env.RELEASE_VERSION
+
+          if (!version) {
+            throw new Error('RELEASE_VERSION is empty.')
+          }
+
+          const manifestChecks = {
+            windows: 'latest.yml',
+            macos: 'latest-mac.yml',
+            linux: 'latest-linux.yml'
+          }
+
+          const platforms = Object.fromEntries(
+            Object.entries(manifestChecks).map(([platform, manifest]) => {
+              const manifestPath = path.join(releaseDir, manifest)
+              const ok = fs.existsSync(manifestPath) && fs.statSync(manifestPath).isFile() && fs.statSync(manifestPath).size > 0
+
+              return [
+                platform,
+                {
+                  manifest,
+                  ok
+                }
+              ]
+            })
+          )
+
+          const health = {
+            ok: Object.values(platforms).every((platform) => platform.ok),
+            version,
+            platforms,
+            generated_at: new Date().toISOString()
+          }
+
+          const healthPath = path.join(releaseDir, 'health.json')
+          fs.writeFileSync(healthPath, `${JSON.stringify(health, null, 2)}\n`)
+
+          console.log(`Generated ${healthPath}:`)
+          console.log(JSON.stringify(health, null, 2))
+
+          if (!health.ok) {
+            const missingManifests = Object.values(platforms)
+              .filter((platform) => !platform.ok)
+              .map((platform) => platform.manifest)
+              .join(', ')
+
+            throw new Error(`Release health check failed. Missing or empty manifests: ${missingManifests}`)
+          }
+          NODE
+
       - name: Generate GitHub Release Page
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
### Motivation

- Ensure a machine-readable `health.json` is produced for each release so consumers (GitHub assets and Cloudflare R2) can verify release health before serving updates. 
- Verify the presence and non-empty contents of three platform manifests (`latest.yml`, `latest-mac.yml`, `latest-linux.yml`) and surface a failure early if any are missing. 
- Attach the generated health manifest to existing release artifacts so it is uploaded to both GitHub Releases and the Cloudflare R2 channel directories.

### Description

- Added a `Generate release health manifest` step to `.github/workflows/build.yml` that runs before the GitHub release page generation and R2 upload. 
- The step runs an inline Node.js script which checks `release_files/latest.yml`, `release_files/latest-mac.yml`, and `release_files/latest-linux.yml`, then writes `release_files/health.json` containing `ok`, `version`, per-platform `ok` flags and `generated_at`. 
- The step reads the release version from `RELEASE_VERSION` (wired to `needs.prepare.outputs.version`) and fails the workflow with a clear error if any manifest is missing or empty. 
- No changes required to the upload steps because `files: release_files/*` (GitHub) and the existing `aws s3 sync release_files/ ...` (Cloudflare R2) will include `health.json` automatically.

### Testing

- Ran `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/build.yml'); puts 'YAML OK'"` and it returned `YAML OK` indicating the workflow YAML is valid. 
- Ran `git diff --check` and there were no check failures. 
- Performed a local Node.js smoke test by creating a temporary `release_files` with `latest.yml`, `latest-mac.yml`, and `latest-linux.yml`, running the inline script with `RELEASE_VERSION=1.2.3`, and confirmed `release_files/health.json` was produced with top-level `ok: true` and `version: "1.2.3"`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20e11d3788832eb22ca885be74b3d2)