### PR TITLE
ci: enforce semver tag formats and make release manifests channel-aware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,26 +71,26 @@ jobs:
             IS_FEATURE=true
           fi
 
-          if [[ "$IS_MAIN" == true && "$VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+          if [[ "$IS_MAIN" == true && "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Stable Release (main)"
             echo "is_dev=false" >> $GITHUB_OUTPUT
             echo "prerelease=false" >> $GITHUB_OUTPUT
             echo "make_latest=true" >> $GITHUB_OUTPUT
             echo "r2_channel=latest" >> $GITHUB_OUTPUT
-          elif [[ "$IS_DEVELOP" == true && "$VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}-[bBrR].*$ ]]; then
-            echo "Beta/RC Release (develop)"
+          elif [[ "$IS_DEVELOP" == true && "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$ ]]; then
+            echo "Beta Release (develop)"
             echo "is_dev=true" >> $GITHUB_OUTPUT
             echo "prerelease=true" >> $GITHUB_OUTPUT
             echo "make_latest=false" >> $GITHUB_OUTPUT
             echo "r2_channel=beta" >> $GITHUB_OUTPUT
-          elif [[ "$IS_FEATURE" == true && "$VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}-[aA].*$ ]]; then
+          elif [[ "$IS_FEATURE" == true && "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]]; then
             echo "Alpha Release (feature)"
             echo "is_dev=true" >> $GITHUB_OUTPUT
             echo "prerelease=true" >> $GITHUB_OUTPUT
             echo "make_latest=false" >> $GITHUB_OUTPUT
             echo "r2_channel=alpha" >> $GITHUB_OUTPUT
           else
-            echo "::error::Tag $TAG does not match branch release policy."
+            echo "::error::Tag $TAG does not match branch release policy. Use vX.Y.Z on main, vX.Y.Z-beta.N on develop, or vX.Y.Z-alpha.N on feature/* branches."
             exit 1
           fi
 
@@ -121,21 +121,21 @@ jobs:
             artifact_pattern: |
               dist/*.exe
               dist/*.blockmap
-              dist/latest*.yml
+              dist/*.yml
           - os: ubuntu-latest
             platform: linux
             artifact_pattern: |
               dist/*.AppImage
               dist/*.deb
               dist/*.rpm
-              dist/latest*.yml
+              dist/*.yml
           - os: macos-latest
             platform: mac
             artifact_pattern: |
               dist/*.dmg
               dist/*.zip
               dist/*.blockmap
-              dist/latest*.yml
+              dist/*.yml
 
     steps:
       - name: Checkout code
@@ -242,6 +242,7 @@ jobs:
       - name: Generate release health manifest
         env:
           RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+          R2_CHANNEL: ${{ needs.prepare.outputs.r2_channel }}
         run: |
           set -euo pipefail
 
@@ -251,15 +252,20 @@ jobs:
 
           const releaseDir = 'release_files'
           const version = process.env.RELEASE_VERSION
+          const channel = process.env.R2_CHANNEL
 
           if (!version) {
             throw new Error('RELEASE_VERSION is empty.')
           }
 
+          if (!channel) {
+            throw new Error('R2_CHANNEL is empty.')
+          }
+
           const manifestChecks = {
-            windows: 'latest.yml',
-            macos: 'latest-mac.yml',
-            linux: 'latest-linux.yml'
+            windows: `${channel}.yml`,
+            macos: `${channel}-mac.yml`,
+            linux: `${channel}-linux.yml`
           }
 
           const platforms = Object.fromEntries(


### PR DESCRIPTION
### Motivation
- Enforce stricter tag naming policies so releases follow explicit semver and channel conventions for `main`, `develop`, and `feature/*` branches.
- Make artifact selection and the release health manifest aware of the release channel so non-`latest` channels (alpha/beta) are supported correctly.

### Description
- Tighten tag regexes to require three-part semver on `main` and explicit `-beta.N` / `-alpha.N` suffix formats on `develop` and `feature/*` branches respectively, and update the error message to describe the expected formats.
- Broaden artifact globbing from `dist/latest*.yml` to `dist/*.yml` for all platforms so channel-specific YAML files are collected.
- Pass `R2_CHANNEL` into the release health manifest step and update the Node manifest generation to require the `R2_CHANNEL` env and to look for `${channel}.yml`, `${channel}-mac.yml`, and `${channel}-linux.yml` instead of hard-coded `latest` filenames.
- Small build-step message/title tweaks (e.g., label `Beta Release (develop)`) and safety checks added to fail early when `R2_CHANNEL` is missing.

### Testing
- No project unit tests were changed; the modifications are limited to the GitHub Actions workflow and release manifest generation logic.
- Workflow YAML and the updated Node snippet were statically validated (YAML parse/lint and JS syntax checks) and are ready for validation by CI on the next workflow run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20e94abea4832ea71bc18fb83f795e)