### PR TITLE
Add multi-platform GitHub Actions workflow for Snaptium dev builds (#…

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,0 +1,79 @@
+name: Snaptium Dev Build
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  dev-build:
+    name: Dev Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2022, ubuntu-latest, macos-latest]
+        arch: [x64]
+        include:
+          - os: windows-2022
+            platform: win
+            artifact_pattern: |
+              dist/*.exe
+              dist/*.blockmap
+              dist/*.yml
+          - os: ubuntu-latest
+            platform: linux
+            artifact_pattern: |
+              dist/*.AppImage
+              dist/*.deb
+              dist/*.rpm
+              dist/*.yml
+          - os: macos-latest
+            platform: mac
+            artifact_pattern: |
+              dist/*.dmg
+              dist/*.zip
+              dist/*.blockmap
+              dist/*.yml
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: npm
+          check-latest: true
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build development package for ${{ matrix.platform }}
+        run: npm run dist:${{ matrix.platform }} -- --publish never
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+          ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES: true
+          USE_HARD_LINKS: false
+
+      - name: Upload development package artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: Snaptium-dev-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.sha }}
+          path: ${{ matrix.artifact_pattern }}
+          retention-days: 7
+          if-no-files-found: error


### PR DESCRIPTION
…155)

### Motivation
- Provide a reproducible dev build workflow that produces platform-specific artifacts for Windows, Linux, and macOS.
- Standardize Node environment and build steps to enable consistent development packaging and artifact collection.

### Description
- Add `.github/workflows/dev-build.yml` which defines a manual `Snaptium Dev Build` workflow with a matrix for `windows-2022`, `ubuntu-latest`, and `macos-latest`.
- Use `actions/setup-node@v5` to set Node `20`, run `npm ci`, `npm run lint`, and execute platform builds via `npm run dist:${{ matrix.platform }}` with environment overrides for the builder.
- Upload platform-specific build artifacts using `actions/upload-artifact@v5` with per-platform `artifact_pattern` and a 7-day retention.
- Configure concurrency, permissions, timeout, and npm caching to stabilize and accelerate runs.

### Testing
- The workflow includes an automated lint step that runs `npm run lint` as part of the job.
- No CI executions were triggered for this PR, so no automated runs have been reported as succeeded or failed yet.

------
[Codex
Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a325111a898832ea3d30a55d9dd1580)