### PR TITLE
Bump GitHub Actions Node.js runner to 22 and regenerate lockfile

### DIFF
--- a/.github/workflows/build-store.yml
+++ b/.github/workflows/build-store.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           check-latest: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,7 +231,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           check-latest: true
 

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           check-latest: true
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2301,9 +2301,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2321,9 +2318,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2341,9 +2335,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2361,9 +2352,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2381,9 +2369,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2401,9 +2386,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
### Motivation
- Align CI runner Node.js version with dependency engine requirements that require Node >= 22.12.0 for certain packages.
- Ensure builds use a current Node runtime to avoid runtime mismatches during packaging and distribution steps.

### Description
- Update `actions/setup-node` `node-version` from `20` to `22` in `.github/workflows/build.yml`, `.github/workflows/dev-build.yml`, and `.github/workflows/build-store.yml`.
- Regenerate `package-lock.json`, which removed several platform-specific `libc` entries and updated dependency metadata to match the environment.
- No source code or application logic changes were made; only CI workflow and lockfile updates were committed.

### Testing
- No automated test suite was executed as part of this change; CI workflows were updated and will run on the next workflow dispatch or push.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a422540ee30832eb414a03e9b9f583b)