### PR TITLE
CI: upgrade Node.js to 22, install npm@10.10, and add @mapbox/node-pre-gyp override

### DIFF
--- a/.github/workflows/build-store.yml
+++ b/.github/workflows/build-store.yml
@@ -34,9 +34,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           check-latest: true
+
+      - name: Use npm 10.10+
+        run: npm install -g npm@10.10.0
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,9 +231,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           check-latest: true
+
+      - name: Use npm 10.10+
+        run: npm install -g npm@10.10.0
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -53,9 +53,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           check-latest: true
+
+      - name: Use npm 10.10+
+        run: npm install -g npm@10.10.0
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund

--- a/package-lock.json
+++ b/package-lock.json
@@ -2301,9 +2301,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2321,9 +2318,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2341,9 +2335,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2361,9 +2352,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2381,9 +2369,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2401,9 +2386,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -241,6 +241,7 @@
     "dmg-license": "^1.0.11"
   },
   "overrides": {
+    "@mapbox/node-pre-gyp": "^2.0.3",
     "yarle-evernote-to-md": {
       "fast-xml-parser": "^5.9.3",
       "lodash": "^4.18.1",


### PR DESCRIPTION
### Motivation
- Ensure CI uses a newer Node.js runtime by moving from `node 20` to `node 22` across build workflows for compatibility with newer package engine requirements. 
- Standardize npm to `10.10.0` in CI to avoid npm-related inconsistencies across runners and to match expected toolchain behavior. 
- Resolve a dependency resolution issue by pinning `@mapbox/node-pre-gyp` via `overrides` to ensure reproducible installs.

### Description
- Updated `setup-node` usage in `.github/workflows/build.yml`, `.github/workflows/dev-build.yml`, and `.github/workflows/build-store.yml` to use `node-version: '22'` instead of `'20'`.
- Added a workflow step `Use npm 10.10+` that runs `npm install -g npm@10.10.0` in the same three workflows to lock the npm version used on runners.
- Added an `overrides` entry in `package.json` to pin `@mapbox/node-pre-gyp` to `^2.0.3`.
- Regenerated `package-lock.json` reflecting dependency metadata changes and lockfile updates.

### Testing
- No automated test runs were executed as part of this changelist; CI workflows containing `npm ci`, `npm run lint`, and the build steps will run on the next push or PR and should validate these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a422540ee30832eb414a03e9b9f583b)