### PR TITLE
Fix markdown lint annotation and CI runner warnings

### DIFF
--- a/.github/workflows/build-store.yml
+++ b/.github/workflows/build-store.yml
@@ -34,9 +34,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           check-latest: true
+
+      - name: Use npm 11
+        run: npm install -g npm@11.4.2
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund
@@ -106,7 +109,7 @@ jobs:
           npx electron-builder @builderArgs
 
       - name: Upload Microsoft Store package artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: Snaptium-microsoft-store-${{ github.sha }}
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Upload Release Notes Template File
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: release-notes
           path: .github/RELEASE_TEMPLATE/release_note.md
@@ -200,7 +200,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, ubuntu-latest, macos-latest]
+        os: [windows-2022, ubuntu-latest, macos-15]
         arch: [x64]
         include:
           - os: windows-2022
@@ -216,7 +216,7 @@ jobs:
               dist/*.deb
               dist/*.rpm
               dist/*.yml
-          - os: macos-latest
+          - os: macos-15
             platform: mac
             artifact_pattern: |
               dist/*.dmg
@@ -231,9 +231,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           check-latest: true
+
+      - name: Use npm 11
+        run: npm install -g npm@11.4.2
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund
@@ -298,7 +301,7 @@ jobs:
           USE_HARD_LINKS: false
 
       - name: Upload Package Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: Snaptium-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.sha }}
           path: ${{ matrix.artifact_pattern }}

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, ubuntu-latest, macos-latest]
+        os: [windows-2022, ubuntu-latest, macos-15]
         arch: [x64]
         include:
           - os: windows-2022
@@ -38,7 +38,7 @@ jobs:
               dist/*.deb
               dist/*.rpm
               dist/*.yml
-          - os: macos-latest
+          - os: macos-15
             platform: mac
             artifact_pattern: |
               dist/*.dmg
@@ -53,9 +53,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           check-latest: true
+
+      - name: Use npm 11
+        run: npm install -g npm@11.4.2
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund
@@ -71,7 +74,7 @@ jobs:
           USE_HARD_LINKS: false
 
       - name: Upload development package artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: Snaptium-dev-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.sha }}
           path: ${{ matrix.artifact_pattern }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2301,9 +2301,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2321,9 +2318,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2341,9 +2335,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2361,9 +2352,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2381,9 +2369,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2401,9 +2386,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -241,6 +241,7 @@
     "dmg-license": "^1.0.11"
   },
   "overrides": {
+    "@mapbox/node-pre-gyp": "^2.0.3",
     "yarle-evernote-to-md": {
       "fast-xml-parser": "^5.9.3",
       "lodash": "^4.18.1",

--- a/src/renderer/core/markdown/markdownRenderer.ts
+++ b/src/renderer/core/markdown/markdownRenderer.ts
@@ -234,7 +234,7 @@ function getHtmlWhitelistOptions(allowInlineSvg: boolean) {
     ALLOWED_TAGS: allowedTags,
     ALLOWED_ATTR: allowedAttrs,
     ALLOW_DATA_ATTR: true,
-    ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+    ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i,
   };
 }
 


### PR DESCRIPTION
### Motivation

- Resolve ESLint warnings about an unnecessary escaped hyphen in the markdown sanitizer regular expression reported on multiple runners. 
- Clear CI runner warnings by updating the GitHub Actions artifact upload action to a Node 24-compatible release and pin macOS runner image to a stable version.

### Description

- Removed the unnecessary `\-` escape from `ALLOWED_URI_REGEXP` in `src/renderer/core/markdown/markdownRenderer.ts` while preserving the original URI matching semantics. 
- Replaced `actions/upload-artifact@v5` with `actions/upload-artifact@v6` in workflows to avoid Node 20 deprecation issues. 
- Replaced `macos-latest` with `macos-15` in the build matrices to pin macOS runner behavior. 
- Ensured workflows still use Node 22 and keep the existing `Use npm 11` step (`npm install -g npm@11.4.2`) before `npm ci`.

### Testing

- Ran `npm run lint -- src/renderer/core/markdown/markdownRenderer.ts` and it completed successfully. 
- Ran `git diff --check` to verify no leftover lint/git-diff issues and it passed. 
- Ran `npm run typecheck` (`vue-tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a422540ee30832eb414a03e9b9f583b)