### PR TITLE
docs: add Code of Conduct, Contributing guide, and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,53 @@
+## Summary / 概述
+
+- 
+
+## Type of Change / 改动类型
+
+- [ ] Bug fix / 问题修复
+- [ ] Feature / 新功能
+- [ ] Documentation / 文档
+- [ ] Refactor / 重构
+- [ ] Build, CI, or release / 构建、CI 或发布
+- [ ] Other / 其他：
+
+## Related Issues / 关联 Issue
+
+Closes #
+
+## Changes / 主要改动
+
+- 
+
+## Screenshots or Recordings / 截图或录屏
+
+If this changes the UI, add screenshots or recordings here.
+
+如涉及 UI 改动，请在此添加截图或录屏。
+
+## Testing / 测试
+
+- [ ] `npm run build:main`
+- [ ] `npm run build:preload`
+- [ ] `npm run typecheck`
+- [ ] `npm run lint`
+- [ ] `npm run test:unit`
+- [ ] Not run / 未运行，原因：
+
+## Checklist / 检查清单
+
+- [ ] I kept this pull request focused and avoided unrelated refactors.
+- [ ] I followed the Electron layer boundary: Renderer → Preload/Bridge → Main.
+- [ ] I validated IPC input at the boundary when applicable.
+- [ ] I avoided `any`, `@ts-ignore`, and unnecessary `@ts-expect-error`.
+- [ ] I updated Simplified Chinese locale files for new or changed user-visible UI text.
+- [ ] I updated documentation when behavior, setup, or user-facing functionality changed.
+- [ ] I considered privacy, security, and user-data impact.
+
+- [ ] 我保持了 PR 聚焦，避免无关重构。
+- [ ] 我遵循了 Electron 分层边界：Renderer → Preload/Bridge → Main。
+- [ ] 如涉及 IPC，我已在边界完成输入校验。
+- [ ] 我没有使用 `any`、`@ts-ignore` 或不必要的 `@ts-expect-error`。
+- [ ] 如新增或修改用户可见 UI 文案，我已同步更新简体中文 locale 文件。
+- [ ] 如行为、配置或用户可见功能变化，我已更新文档。
+- [ ] 我已考虑隐私、安全和用户数据影响。

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,65 @@
+# Code of Conduct / 行为准则
+
+## Our Pledge / 我们的承诺
+
+We are committed to making Snaptium a welcoming, respectful, and harassment-free project for everyone, regardless of background, identity, experience level, or viewpoint.
+
+我们致力于让 Snaptium 成为一个友善、尊重、无骚扰的项目社区。无论背景、身份、经验水平或观点如何，每个人都应被平等对待。
+
+## Expected Behavior / 期望行为
+
+Participants are expected to:
+
+- Be respectful, patient, and constructive.
+- Assume good intent, but take responsibility for impact.
+- Keep discussions focused on the project and its users.
+- Give and receive feedback gracefully.
+- Respect maintainers' time and decisions.
+- Protect user privacy and avoid sharing sensitive information.
+
+参与者应当：
+
+- 保持尊重、耐心和建设性。
+- 善意理解他人，同时对自身言行影响负责。
+- 让讨论聚焦于项目与用户价值。
+- 以良好方式提出和接受反馈。
+- 尊重维护者的时间与决定。
+- 保护用户隐私，避免分享敏感信息。
+
+## Unacceptable Behavior / 不可接受行为
+
+The following behavior is not acceptable:
+
+- Harassment, intimidation, threats, or personal attacks.
+- Discriminatory language or behavior.
+- Sexualized language, imagery, or attention.
+- Trolling, repeated off-topic arguments, or deliberate disruption.
+- Publishing private information without explicit permission.
+- Abusive, dismissive, or hostile review comments.
+
+以下行为不可接受：
+
+- 骚扰、恐吓、威胁或人身攻击。
+- 歧视性语言或行为。
+- 性化语言、图像或关注。
+- 引战、反复偏离主题或故意扰乱讨论。
+- 未经明确许可公开他人隐私信息。
+- 攻击性、轻蔑或敌意的评审意见。
+
+## Reporting / 举报方式
+
+If you experience or witness unacceptable behavior, please contact the maintainers through the repository's GitHub channels. For security-sensitive or private matters, use the repository's security reporting process instead of opening a public issue.
+
+如果你遭遇或发现不可接受行为，请通过仓库的 GitHub 渠道联系维护者。涉及安全敏感或隐私内容时，请使用仓库的安全报告流程，不要创建公开 Issue。
+
+## Enforcement / 执行
+
+Maintainers may remove comments, close issues or pull requests, restrict participation, or take other reasonable actions when this Code of Conduct is violated. Enforcement decisions are made to protect the health of the project and its community.
+
+当行为违反本准则时，维护者可以删除评论、关闭 Issue 或 Pull Request、限制参与权限，或采取其他合理措施。执行决定以保护项目和社区健康为目标。
+
+## Scope / 适用范围
+
+This Code of Conduct applies to all Snaptium project spaces, including issues, pull requests, discussions, documentation, and other community interactions connected to the project.
+
+本行为准则适用于 Snaptium 项目的所有空间，包括 Issue、Pull Request、讨论、文档以及与项目相关的其他社区互动。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# Contributing to Snaptium / 参与贡献
+
+Thank you for your interest in contributing to Snaptium. This guide explains how to propose changes safely and consistently.
+
+感谢你有兴趣参与 Snaptium。本指南说明如何安全、一致地提交改动。
+
+## Before You Start / 开始之前
+
+- Read the project README to understand Snaptium's goals and feature scope.
+- Search existing issues and pull requests to avoid duplicate work.
+- For large features, architecture changes, data migration, security-sensitive work, or user-data behavior changes, open an issue first and wait for maintainer feedback.
+- Keep changes focused. Avoid unrelated refactors or formatting-only edits.
+
+- 阅读项目 README，了解 Snaptium 的目标和功能范围。
+- 搜索已有 Issue 和 Pull Request，避免重复工作。
+- 对于大型功能、架构变更、数据迁移、安全敏感改动或影响用户数据的行为，请先创建 Issue 并等待维护者反馈。
+- 保持改动聚焦，避免无关重构或纯格式化改动。
+
+## Development Setup / 开发环境
+
+Snaptium is an Electron + Vue 3 + TypeScript application.
+
+```bash
+npm install
+npm run dev
+```
+
+Useful commands:
+
+```bash
+npm run build:main
+npm run build:preload
+npm run typecheck
+npm run lint
+npm run test:unit
+```
+
+## Architecture Guidelines / 架构约定
+
+Please follow the repository's architecture and development rules:
+
+- Renderer code must not access Node.js APIs directly.
+- Use `window.electronAPI` for renderer-to-system capabilities.
+- Keep IPC channel names centralized in `electron/main/constants/ipc.constants.ts`.
+- Validate IPC input at the boundary.
+- Put system capabilities in main-process services.
+- Keep renderer services responsible for business orchestration.
+- Reuse existing `utils`, `services`, `shared`, or `core` code before adding new helpers.
+- Do not hardcode user-visible UI text; use the existing i18n system and update Simplified Chinese locale files when adding or changing UI text.
+
+请遵循仓库的架构与开发规则：
+
+- Renderer 不得直接访问 Node.js API。
+- Renderer 如需系统能力，应通过 `window.electronAPI`。
+- IPC channel 名称统一维护在 `electron/main/constants/ipc.constants.ts`。
+- IPC 输入必须在边界校验。
+- 系统能力应放在 Main 进程服务中。
+- Renderer service 负责业务编排。
+- 新增 helper 前，优先复用已有 `utils`、`services`、`shared` 或 `core` 代码。
+- 不要硬编码用户可见 UI 文案；应使用现有 i18n 系统，新增或修改 UI 文案时同步更新简体中文 locale 文件。
+
+## TypeScript Guidelines / TypeScript 规则
+
+- Do not use `@ts-ignore`.
+- Avoid `@ts-expect-error`; use it only for a clearly documented boundary reason.
+- Do not use `any`.
+- Use `unknown` only at boundaries, then narrow it immediately.
+- Add explicit types for business interfaces, IPC input/output, service returns, store state, and API responses.
+
+## Commit and Pull Request Expectations / 提交与 Pull Request 要求
+
+Before opening a pull request:
+
+1. Keep the pull request scoped to one purpose.
+2. Update documentation when behavior, setup, or user-facing functionality changes.
+3. Add or update tests when changing logic with existing test coverage.
+4. Run the smallest relevant verification command for your change.
+5. Fill out the pull request template completely.
+
+创建 Pull Request 前：
+
+1. 确保 Pull Request 聚焦于单一目的。
+2. 当行为、配置方式或用户可见功能变化时，同步更新文档。
+3. 修改已有测试覆盖的逻辑时，新增或更新测试。
+4. 根据改动范围运行最小必要验证命令。
+5. 完整填写 Pull Request 模板。
+
+## Security / 安全
+
+Do not report security vulnerabilities in public issues. Follow the repository security policy and use GitHub Security Advisory for responsible disclosure.
+
+请不要在公开 Issue 中报告安全漏洞。请遵循仓库安全策略，通过 GitHub Security Advisory 进行负责任披露。
+
+## License / 许可
+
+By contributing to Snaptium, you agree that your contributions are submitted under the repository's Apache-2.0 license unless explicitly stated otherwise.
+
+向 Snaptium 提交贡献即表示你同意相关贡献默认遵循仓库的 Apache-2.0 许可证，除非另有明确说明。


### PR DESCRIPTION
### Motivation
- Provide community-facing guidelines to welcome contributors and set expectations for behavior and contribution flow.
- Make contribution process explicit with repository-specific architecture, TypeScript, i18n, and verification rules to reduce noisy PRs and misaligned changes.

### Description
- Add `CODE_OF_CONDUCT.md` with bilingual (English / 简体中文) expected behavior, unacceptable behavior, reporting, enforcement, and scope sections.
- Add `CONTRIBUTING.md` with bilingual developer guidance including setup commands, architecture rules (Electron boundaries, IPC, reuse), TypeScript rules, PR expectations, security reporting, and license note.
- Add `.github/pull_request_template.md` as a bilingual GitHub pull request template containing summary, change type, related issues, testing checklist, screenshots, and a project-specific checklist.

### Testing
- Ran `git diff --check -- CODE_OF_CONDUCT.md CONTRIBUTING.md .github/pull_request_template.md`, which produced no whitespace/error warnings and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4753568e5c832e98d8e9a822b3666c)